### PR TITLE
don't call `text()` twice on the same `response` object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -99,9 +99,10 @@ Reporter.handleFetchResponse = (mode, response) => (
         }
 
         if (mode === 'Robot.XML') {
-            return response.text()
+            var text_promise = response.text()
+            return text_promise
                 .then(xml2js.parseStringAsync)
-                .then(util.xmlErrorThrower, () => response.text().then(util.textErrorThrower));
+                .then(util.xmlErrorThrower, () => text_promise.then(util.textErrorThrower));
         }
 
         return response.text().then(util.textErrorThrower);


### PR DESCRIPTION
prevents "body used already" error ( originating from `node-fetch` )