### PR TITLE
Add functionality to automatically retrieve/generate access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,42 +22,82 @@ yarn add apple-reporter
 
 ### Initialization
 
+You can initialize an `AppleReporter` with an access token or the account password.
+
 ```js
 const AppleReporter = require('apple-reporter');
 
 const reporter = new AppleReporter({
-    userid: 'gy',
-    accesstoken: 'your-itunesconnect-access-token'
+    userid: 'your-itunesocnnect-userid',
+    accesstoken: 'your-itunesconnect-access-token',
+});
+
+// OR:
+const reporter = new AppleReporter({
+    userid: 'your-itunesocnnect-userid',
+    password: 'your-itunesconnect-account-password',
 });
 ```
+If you supply a **password**, note that an access token **is still required** to fetch data.
+However, supplying a password allows you to call `reporter.retrieveAccessToken()` to automatically retrieve and set the access token for the account:
+
+```js
+const AppleReporter = require('apple-reporter');
+
+const reporter = new AppleReporter({
+    userid: 'your-itunesocnnect-userid',
+    password: 'your-itunesconnect-account-password',
+});
+
+reporter.retrieveAccessToken()
+.then(({ token }) => {
+    console.log(`The account access token is ${token}`);
+    
+    // Other methods will now work (see 'Usage' section)
+})
+```
+
+`retrieveAccessToken()` will normally throw an error if your account does not have an access token, or the access token is expired.
+However, if called with the optional `generateNewIfNeeded: true`, a new access code will simply be generated in these scenarios:
+
+```js
+reporter.retrieveAccessToken({ generateNewIfNeeded: true })
+.then(({ token, isNew }) => {
+    console.log(`Token: ${token}, was newly generated: ${isNew}`);
+    
+    // Other API methods will now work (see 'Usage' section)
+})
+```
+
+If you supply an access token to begin with, you do not need to call this method before using the rest of the library.
 
 ### Usage
 
-```js
-function getFinanceReport() {
-    return reporter.Finance.getStatus().then((status) => {
-        return reporter.Finance.getReport({
-            vendorNumber: 123456,
-            regionCode: 'US',
-            reportType: 'Financial',
-            fiscalYear: '2015',
-            fiscalPeriod: '02'
-        })
-        .then((report) => {
-            // do stuff with report...
-        })
-        .catch((err) => {
-            // uh-oh!
-            console.error('Unable to get Finance report!');
+Example:
 
-            throw err;
-        });
-    }, (err) => {
-        console.error('Finance is down!');
+```js
+reporter.Finance.getStatus().then((status) => {
+    return reporter.Finance.getReport({
+        vendorNumber: 123456,
+        regionCode: 'US',
+        reportType: 'Financial',
+        fiscalYear: '2015',
+        fiscalPeriod: '02'
+    })
+    .then((report) => {
+        // do stuff with report...
+    })
+    .catch((err) => {
+        // uh-oh!
+        console.error('Unable to get Finance report!');
 
         throw err;
     });
-}
+}, err => {
+    console.error('Finance is down!');
+
+    throw err;
+});  
 ```
 
 ## API
@@ -70,6 +110,7 @@ Refer to [Apple's documentation](http://help.apple.com/itc/appsreporterguide) fo
   - `financeUrl`: Finance endpoint URL (defaults to `/finance/v1`)
   - `mode`: Either `Normal` or `Robot.XML` (defaults to `Robot.XML`)
   - `accesstoken`: iTunes Connect access token
+  - `password`: iTunes Connect account password
   - `salesUrl`: Sales endpoint URL (defaults to `/sales/v1`)
   - `userid`: iTunes Connect account user ID
   - `version`: The API version (defaults to `1.0`)

--- a/README.md
+++ b/README.md
@@ -52,24 +52,41 @@ const reporter = new AppleReporter({
 reporter.retrieveAccessToken()
 .then(({ token }) => {
     console.log(`The account access token is ${token}`);
-    
+
     // Other methods will now work (see 'Usage' section)
 })
 ```
 
-`retrieveAccessToken()` will normally throw an error if your account does not have an access token, or the access token is expired.
-However, if called with the optional `generateNewIfNeeded: true`, a new access code will simply be generated in these scenarios:
+Normally, `retrieveAccessToken()` will throw an error if your account does not have an access token, or the access token is expired.
+In addition, in the case that an access token has already been retrieved (or given), it will simply return it without re-fetching.
+This behavior can be overidden with options:
+
+```js
+reporter.retrieveAccessToken({
+    // Pass this to generate a new token anyway in the case that
+    // one doesn't exist or is expired
+    generateNewIfNeeded: true
+
+    // Pass this to force re-fetching the account access token,
+    // even if one is already set
+    forceRetrieve: true
+})
+.then(...)
+```
+
+`retrieveAccessToken()` resolves to an object containing the token and a boolean indicating if it was newly generated or not:
 
 ```js
 reporter.retrieveAccessToken({ generateNewIfNeeded: true })
 .then(({ token, isNew }) => {
     console.log(`Token: ${token}, was newly generated: ${isNew}`);
-    
+
     // Other API methods will now work (see 'Usage' section)
 })
 ```
 
 If you supply an access token to begin with, you do not need to call this method before using the rest of the library.
+In the case that you only supply a password, the rest of the API will not work until this method has been called.
 
 ### Usage
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,16 @@ const xml2js = require('xml2js');
 const fetch = require('./fetch');
 const util = require('./util');
 
+const AppleReporterError = require('./errors').AppleReporterError;
+
 Promise.promisifyAll(xml2js);
+
+const errorMessages = {
+    passwordRequired: 'This method requires the account password (not just an access token)',
+    accessTokenRequired: 'This method requires an access token, but no access token was supplied and retrieveAccessToken() was not called',
+    needsNewAccessToken: 'Access token doesn\'t exist or is expired, pass { generateNewIfNeeded: true } to force generation of a new token',
+    accessTokenSupplied: 'retrieveAccessToken() was called, but an access token was supplied at creation'
+};
 
 class Sales {
     constructor(context) {
@@ -57,18 +66,27 @@ class Reporter {
         this.Finance = new Finance(this);
     }
 
-    fetch(serviceUrl, params) {
+    fetchRaw(serviceUrl, params, usePassword = false) {
         return Promise.try(() => {
             const url = `${this.config.baseUrl}${serviceUrl}`;
 
             const data = {
                 userid: this.config.userid,
-                accesstoken: this.config.accesstoken,
                 account: this.config.account,
                 version: this.config.version,
                 mode: this.config.mode,
                 queryInput: `[p=Reporter.properties, ${params}]`
             };
+
+            if (usePassword && this.config.password == null) throw new AppleReporterError(errorMessages.passwordRequired);
+            if (!usePassword && this.config.accesstoken == null) throw new AppleReporterError(errorMessages.accessTokenRequired);
+
+            if (usePassword) {
+                data.password = this.config.password;
+            }
+            else {
+                data.accesstoken = this.config.accesstoken;
+            }
 
             const method = 'POST';
 
@@ -78,8 +96,59 @@ class Reporter {
 
             const body = `jsonRequest=${JSON.stringify(data)}`;
 
-            return fetch(url, { method, body, headers })
-                .then((response) => Reporter.handleFetchResponse(this.config.mode, response));
+            return fetch(url, { method, body, headers });
+        });
+    }
+
+    fetch(serviceUrl, params, usePassword = false) {
+        return this.fetchRaw(serviceUrl, params, usePassword).then((response) => Reporter.handleFetchResponse(this.config.mode, response));
+    }
+
+    retrieveAccessToken(options = {}) {
+        // We need a password to do this
+        if (this.config.password == null) throw new AppleReporterError(errorMessages.passwordRequired);
+
+        // If they already supplied an access token at creation, why are they calling this?
+        if (this.config.accesstoken != null) console.warn(errorMessages.accessTokenSupplied);
+
+        let newTokenWasGenerated = false;
+
+        return this.fetch(this.config.salesUrl, '[Sales.viewToken]', true)
+        .then((result) => {
+            if (result.ViewToken.Message != null) return null;
+
+            const expDate = new Date(result.ViewToken.ExpirationDate[0]);
+            const accessToken = result.ViewToken.AccessToken[0];
+
+            if (new Date() < expDate) return accessToken;
+            return null;
+        })
+        .then((maybeAccessToken) => {
+            // If it was retrieved and not expired, return it
+            if (maybeAccessToken != null) return maybeAccessToken;
+
+            // Otherwise, we need to generate one, but only if generateNewIfNeeded is set
+            if (options.generateNewIfNeeded == null || !options.generateNewIfNeeded) throw new AppleReporterError(errorMessages.needsNewAccessToken);
+
+            newTokenWasGenerated = true;
+
+            const url = this.config.salesUrl; // Doesn't matter
+            const params = '[Sales.generateToken]';
+
+            return this.fetchRaw(url, params, true)
+            .then((intermediateResponse) => {
+                // To complete this kind of request, we have to make another request with some
+                // particular URL params, referencing the service request id passed in these response headers
+                const requestId = intermediateResponse.headers.service_request_id;
+                // Do a regular fetch so the result will get parsed
+                return this.fetchRaw(`${url}?isExistingToken=Y&requestId=${requestId}`, params, true);
+            })
+            .then((response) => Reporter.handleFetchResponse(this.config.mode, response))
+            .then((accessTokenResponse) => accessTokenResponse.ViewToken.AccessToken[0]);
+        })
+        .then((accessToken) => {
+            this.config.accesstoken = accessToken;
+            return { token: accessToken, isNew: newTokenWasGenerated };
         });
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ const AppleReporterError = require('./errors').AppleReporterError;
 Promise.promisifyAll(xml2js);
 
 const errorMessages = {
-    passwordRequired: 'This method requires the account password (not just an access token)',
+    passwordRequired: 'Retrieving the access token requires the account password, but no password was supplied',
     accessTokenRequired: 'This method requires an access token, but no access token was supplied and retrieveAccessToken() was not called',
     needsNewAccessToken: 'Access token doesn\'t exist or is expired, pass { generateNewIfNeeded: true } to force generation of a new token',
     accessTokenSupplied: 'retrieveAccessToken() was called, but an access token was supplied at creation'
@@ -105,9 +105,6 @@ class Reporter {
     }
 
     retrieveAccessToken(options = {}) {
-        // We need a password to do this
-        if (this.config.password == null) throw new AppleReporterError(errorMessages.passwordRequired);
-
         if (this.config.accesstoken != null) {
             // If we've already retrieved the access token (or one was given), skip retrieval
             // unless the user specifically asks to force retrieval
@@ -115,6 +112,9 @@ class Reporter {
                 return Promise.resolve({ token: this.config.accesstoken, isNew: false });
             }
         }
+
+        // If we get here and we don't have a password, that's a problem
+        if (this.config.password == null) throw new AppleReporterError(errorMessages.passwordRequired);
 
         let newTokenWasGenerated = false;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -108,8 +108,13 @@ class Reporter {
         // We need a password to do this
         if (this.config.password == null) throw new AppleReporterError(errorMessages.passwordRequired);
 
-        // If they already supplied an access token at creation, why are they calling this?
-        if (this.config.accesstoken != null) console.warn(errorMessages.accessTokenSupplied);
+        if (this.config.accesstoken != null) {
+            // If we've already retrieved the access token (or one was given), skip retrieval
+            // unless the user specifically asks to force retrieval
+            if (options.forceRetrieve == null || !options.forceRetrieve) {
+                return Promise.resolve({ token: this.config.accesstoken, isNew: false });
+            }
+        }
 
         let newTokenWasGenerated = false;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -173,10 +173,10 @@ Reporter.handleFetchResponse = (mode, response) => (
         }
 
         if (mode === 'Robot.XML') {
-            var text_promise = response.text()
-            return text_promise
+            const textPromise = response.text();
+            return textPromise
                 .then(xml2js.parseStringAsync)
-                .then(util.xmlErrorThrower, () => text_promise.then(util.textErrorThrower));
+                .then(util.xmlErrorThrower, () => textPromise.then(util.textErrorThrower));
         }
 
         return response.text().then(util.textErrorThrower);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-reporter",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Promise-based Apple iTunes Connect Reporter",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "lint": "eslint lib",
     "prepublishOnly": "npm run check",
-    "test": "nyc mocha -R spec --compilers js:babel-register 'test/**/*.test.js'"
+    "test": "nyc mocha -R spec --compilers js:babel-register -- test/**/*.test.js"
   },
   "repository": {
     "type": "git",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -49,7 +49,7 @@ describe('Reporter', function () {
                 'https://reportingitc-reporter.apple.com/reportservice/sales/v1',
                 {
                     method: 'POST',
-                    body: 'jsonRequest={"userid":"gy","accesstoken":"itunesconnect-access-token","version":"1.0","mode":"Robot.XML","queryInput":"[p=Reporter.properties, Sales.getReport, 123456,Sales,Summary,Weekly,20150208]"}',
+                    body: 'jsonRequest={"userid":"gy","version":"1.0","mode":"Robot.XML","queryInput":"[p=Reporter.properties, Sales.getReport, 123456,Sales,Summary,Weekly,20150208]","accesstoken":"itunesconnect-access-token"}',
                     headers: {
                         'Content-Type': 'application/x-www-form-urlencoded'
                     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,6 +13,7 @@ const Reporter = require('../lib/index');
 
 const userid = 'gy';
 const accesstoken = 'itunesconnect-access-token';
+const password = 'itunesconnect-account-password';
 
 describe('Reporter', function () {
     const reporter = new Reporter({ userid, accesstoken });
@@ -306,5 +307,31 @@ describe('Reporter', function () {
                 expect(reporter.Finance.getVersion()).to.eventually.equal('1.0');
             });
         });
+    });
+
+    it('should have retrieveAccessToken', function () {
+        expect(reporter.retrieveAccessToken).to.be.a('function');
+    });
+
+    const reporterWithNoAuth = new Reporter({ userid });
+    const reporterWithPassword = new Reporter({ userid, password });
+    const reporterWithToken = new Reporter({ userid, accesstoken });
+
+    describe('retrieveAccessToken', function () {
+
+        it('should throw if no password or access code supplied', function () {
+            expect(() => reporterWithNoAuth.retrieveAccessToken()).to.throw();
+        });
+
+        it('should not throw if access token already supplied', function () {
+            expect(() => reporterWithToken.retrieveAccessToken()).to.not.throw();
+        });
+
+        it('should throw if forceRetrieve is set but not password was supplied', function () {
+            expect(() => reporterWithToken.retrieveAccessToken({ forceRetrieve: true })).to.throw();
+        });
+
+        // TODO: Test the actual behavior
+
     });
 });


### PR DESCRIPTION
You can now initialize an apple reporter with an access token (if you have one) **or** the account password.
When you use the latter option, you can call `retrieveAccessToken()` or `retrieveAccessToken({ generateNewIfNeeded: true })` to configure the access token before using the rest of the library.