### PR TITLE
Fix build toolchain and npm publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+# Intellij
+.idea
+*.iml
+
+# Node.js
+node_modules
+yarn.lock
+coverage
+coverage.lcov
+.nyc_output
+
+# Don't ignore dist in this file, so that the built contents are published

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-reporter",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Promise-based Apple iTunes Connect Reporter",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "xml2js": "^0.4.17"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
     "babel-core": "^6.18.2",
     "babel-preset-env": "^0.0.8",
     "babel-register": "^6.18.0",


### PR DESCRIPTION
`dist` folder is ignored by `npm publish`, so installers get no actual code when they install! Also, `npm run build` was broken.