### PR TITLE
Add ability to pass default retrieveAccessToken() options in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ Refer to [Apple's documentation](http://help.apple.com/itc/appsreporterguide) fo
   - `salesUrl`: Sales endpoint URL (defaults to `/sales/v1`)
   - `userid`: iTunes Connect account user ID
   - `version`: The API version (defaults to `1.0`)
+  - `tokenOptions`: (object) The options object used in `retrieveAccessToken()`, if none is passed to the method
+    - `forceRetrieve`: Actually make an API call to retrieve the token, even if one is already set (defaults to `false`)
+    - `generateNewIfNeeded`: Generate a new token automatically if it is found to be expired or non-existent (defaults to `false`)
 
 ### General
 - [getVersion](https://help.apple.com/itc/appsreporterguide/#/itc7e183be3b)

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,12 +54,16 @@ class Finance {
 
 class Reporter {
     constructor(config) {
-        this.config = _.defaults(config, {
+        this.config = _.defaultsDeep(config, {
             baseUrl: 'https://reportingitc-reporter.apple.com/reportservice',
             financeUrl: '/finance/v1',
             mode: 'Robot.XML',
             salesUrl: '/sales/v1',
-            version: '1.0'
+            version: '1.0',
+            tokenOptions: {
+                forceRetrieve: false,
+                generateNewIfNeeded: false
+            }
         });
 
         this.Sales = new Sales(this);
@@ -104,7 +108,9 @@ class Reporter {
         return this.fetchRaw(serviceUrl, params, usePassword).then((response) => Reporter.handleFetchResponse(this.config.mode, response));
     }
 
-    retrieveAccessToken(options = {}) {
+    retrieveAccessToken(customOptions = null) {
+        const options = _.merge(this.config.tokenOptions, customOptions);
+
         if (this.config.accesstoken != null) {
             // If we've already retrieved the access token (or one was given), skip retrieval
             // unless the user specifically asks to force retrieval

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-reporter",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Promise-based Apple iTunes Connect Reporter",
   "main": "dist/index.js",
   "files": [

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,6 +25,9 @@ describe('Reporter', function () {
         expect(reporter.config).to.have.property('mode', 'Robot.XML');
         expect(reporter.config).to.have.property('salesUrl', '/sales/v1');
         expect(reporter.config).to.have.property('version', '1.0');
+        expect(reporter.config).to.have.property('tokenOptions');
+        expect(reporter.config.tokenOptions).to.have.property('forceRetrieve', false);
+        expect(reporter.config.tokenOptions).to.have.property('generateNewIfNeeded', false);
     });
 
     describe('getVersion', function () {


### PR DESCRIPTION
Eliminates having to pass the usual options every time, if you're going to use the same settings always.