### PR TITLE
Fix #10 - Add reportVersion parameter to getReport function.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ class Sales {
         }
 
         this.getAccounts = create('getAccounts');
-        this.getReport = create('getReport', ['vendorNumber', 'reportType', 'reportSubType', 'dateType', 'date']);
+        this.getReport = create('getReport', ['vendorNumber', 'reportType', 'reportSubType', 'dateType', 'date', 'reportVersion']);
         this.getStatus = create('getStatus');
         this.getVendors = create('getVendors');
         this.getVersion = _.bind(context.getVersion, context);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apple-reporter",
   "version": "2.2.0",
   "description": "Promise-based Apple iTunes Connect Reporter",
-  "main": "dist/index.js",
+  "main": "lib/index.js",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "apple-reporter",
   "version": "2.2.0",
   "description": "Promise-based Apple iTunes Connect Reporter",
-  "main": "lib/index.js",
+  "main": "dist/index.js",
   "files": [
-    "lib"
+    "dist"
   ],
   "scripts": {
     "build": "babel lib --out-dir dist",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "apple-reporter",
   "version": "2.2.0",
   "description": "Promise-based Apple iTunes Connect Reporter",
-  "main": "dist/index.js",
+  "main": "lib/index.js",
   "files": [
-    "dist"
+    "lib"
   ],
   "scripts": {
     "build": "babel lib --out-dir dist",


### PR DESCRIPTION
As Apple changed iTunes Connect API's `getReport` does not work anymore, unless `reportVersion` `1_1` is added to the parameters. The method needs to support this parameter, as it is ignored otherwise. Effectively this closes issue #10, which describes the workaround in detail.

Add it to your `getReport` call like this:

```
reporter.Sales.getReport({
        vendorNumber: 12345678,
        reportType: 'Subscriber',
        reportSubType: 'Detailed',
        dateType: 'Daily',
        reportVersion: '1_1',
        date: date
    });
```